### PR TITLE
Fix code scanning alert no. 24: Resource injection

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -21,7 +21,10 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public SqliteDbProvider(ConfigFile configFile)
         {
-            _connectionString = string.Format("Data Source={0};Version=3", configFile.Get(DbConstants.KEY_FILE_NAME));
+            var builder = new SqliteConnectionStringBuilder();
+            builder.DataSource = configFile.Get(DbConstants.KEY_FILE_NAME);
+            builder.Version = 3;
+            _connectionString = builder.ConnectionString;
 
             _clientExec = configFile.Get(DbConstants.KEY_CLIENT_EXEC);
             _dbFileName = configFile.Get(DbConstants.KEY_FILE_NAME);


### PR DESCRIPTION
Fixes [https://github.com/mohamed-mahmoud-webjet/ghas-demo-csharp/security/code-scanning/24](https://github.com/mohamed-mahmoud-webjet/ghas-demo-csharp/security/code-scanning/24)

To fix the problem, we should use a connection string builder class that safely constructs the connection string without directly concatenating user input. For SQLite, we can use the `SqliteConnectionStringBuilder` class provided by the `Mono.Data.Sqlite` namespace. This class ensures that user input is properly escaped and does not alter the structure of the connection string.

We will modify the `SqliteDbProvider` constructor to use `SqliteConnectionStringBuilder` to construct the connection string. This change will be made in the `WebGoat/App_Code/DB/SqliteDbProvider.cs` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
